### PR TITLE
Fix wrong dependabot submodules config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "gitsubmodule"
-    directory: "/opt"
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "gitsubmodule"
-    directory: "/start"
+    directory: "/"
     schedule:
       interval: "daily"
 


### PR DESCRIPTION
I misunderstood how "directory" works for telling dependabot where to find submodules.