### PR TITLE
Fix "Check Markdown links" CI workflow

### DIFF
--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -2,8 +2,6 @@ name: Check Markdown links
 
 on:
   push:
-    branches:
-      - main
   pull_request:
   schedule:
     - cron: '15 0,12 * * *'


### PR DESCRIPTION
It listed main, but this repo has master.

This commit changes it to run for all branches.